### PR TITLE
Remove mexico dependency

### DIFF
--- a/R/SIR.R
+++ b/R/SIR.R
@@ -3,11 +3,17 @@
 #' @param draws data.frame of prior draws for SIR
 #' @param deplete.mean Final year depletion (not in log space)
 #' @param deplete.cv Final year CV, used as SD
+#' @param pct.keep The percentage of "keepers" from the total. Default 10%.
+#' @param harvest.sd, harvest.mean The mean and SD of the terminal year
+#'   penalty on fishing pressure. If either is NULL it is ignored.
+#' @param NY Number of years
+#' @param Catch Vector of catches
 #' @return A list containing depletion, SSB, and harvest rate (U) for
 #'   posterior draws, and a vector of Keepers
-run.SIR <- function(draws, deplete.mean=NULL, deplete.cv=NULL, harvest.mean=NULL,
-                    harvest.sd=NULL, pct.keep=10){
+run.SIR <- function(NY, Catch, draws, deplete.mean=NULL, deplete.cv=NULL,
+                    harvest.mean=NULL, harvest.sd=NULL, pct.keep=10){
   ## store results
+  nrep <- nrow(draws)
   Bstore <- array(dim=c(NY,nrep))
   Dstore <- array(dim=c(NY,nrep))
   Ustore <- array(dim=c(NY,nrep))
@@ -16,7 +22,6 @@ run.SIR <- function(draws, deplete.mean=NULL, deplete.cv=NULL, harvest.mean=NULL
   ## #########################
   ## run iterations
   ## #########################
-  nrep <- nrow(draws)
   for (irep in 1:nrep){   ##loop over replicates
     ## set priors
     InitialDeplete <- draws$InitialPrior[irep]

--- a/R/SIR.R
+++ b/R/SIR.R
@@ -6,14 +6,14 @@
 #' @param pct.keep The percentage of "keepers" from the total. Default 10%.
 #' @param harvest.sd, harvest.mean The mean and SD of the terminal year
 #'   penalty on fishing pressure. If either is NULL it is ignored.
-#' @param NY Number of years
-#' @param Catch Vector of catches
+#' @param Catch Vector of catches, one for each year.
 #' @return A list containing depletion, SSB, and harvest rate (U) for
 #'   posterior draws, and a vector of Keepers
-run.SIR <- function(NY, Catch, draws, deplete.mean=NULL, deplete.cv=NULL,
+run.SIR <- function(Catch, draws, deplete.mean=NULL, deplete.cv=NULL,
                     harvest.mean=NULL, harvest.sd=NULL, pct.keep=10){
   ## store results
   nrep <- nrow(draws)
+  NY <- length(Catch)
   Bstore <- array(dim=c(NY,nrep))
   Dstore <- array(dim=c(NY,nrep))
   Ustore <- array(dim=c(NY,nrep))

--- a/R/model.R
+++ b/R/model.R
@@ -3,6 +3,7 @@
 #' @export
 AgeModel <- function(Catch,AgeMat, Steep,NatMort, AgeMax, Carry,Weight,InitialDeplete,Sigma) {
   ## process error devations
+  NYears <- length(Catch)
   devsvector <- rnorm(NYears,mean=0,sd=Sigma)
   ## maximum age
   maxage <- AgeMax

--- a/inst/demo.R
+++ b/inst/demo.R
@@ -1,84 +1,28 @@
-## priors
-## invertebrates
-## figure out how far to push data sources on life history
-## figure out priors for depletion - change in effort
-	## know if species are caught by trawls?
-## swept-area ratio - fraction between area trawled and continental shelf - correlates with fishing mortality rate
-	## india - 10 - nothing long-lived is going to be around with that F
-
-## identify what type of species from databases
-## F prior
-## how to use FMI as depletion measure
-## relationship between trawl, effort, and F
-## species x in area Z but not species y in area Z
-
-### SHORT-TERM
-## extend FishLife for invertebrates
-## or use SeaLife/Base
-## go from FMI to level of depletion
-## FMI fishery score with more than 1 person
-## related to level of depletion, at Bmsy 0.8 or higher, linear down to zero
-## middle of April for invertebrates
-
-rm(list=ls())
+### This file provides a quick demonstration of the package using a
+### hard-coded example.
 library(FishLife)
 library(mvtnorm)
 library(dplyr)
 devtools::load_all('C:/Users/Cole/sraplus')
 library(sraplus)
+## You need to put the file "Return.RData" in the "data" folder of the
+## package. It's too large to include it and should be removed later. Comes
+## from FishLife
+data(Return)
+str(Return)
 
-###################
-## directories
-###################
-main_dir <- system.file(package='sraplus')
-setwd(main_dir)
-data_dir <- file.path(main_dir, "examples")
-
-###########################
-## data
-###########################
-load(file.path(data_dir, "Return.RData"))
-datafile <- file.path(data_dir, "Mexico FAO Catch Data.csv")
-priorfile <- file.path(data_dir, "DeplPrior_wTaxa.csv")
-
-## catch data
-C <- ReadCatchData(File=datafile)
-CatchData <- C$CatchData
-StockInfo <- C$StockInfo
-CStock <- paste(StockInfo$Species..ASFIS.species.,StockInfo$Fishing.area..FAO.major.fishing.area.)
-
-## prior info
-Priors <- ReadPrior(File=priorfile)
-StockList <- paste(Priors$Species..ASFIS.species.,Priors$Fishing.area..FAO.major.fishing.area.)
-
-## indices
-AllYears=seq(1950,2015)
-
-
-###########################
-## choose stock
-###########################
-iStock <- 4
-jStock <- which(CStock==StockList[iStock])
-# data inputs for chosen stock
-Catch <- as.numeric(CatchData[jStock,])
-Years <- AllYears[which(is.na(Catch)==FALSE)]
-Catch <- Catch[which(is.na(Catch)==FALSE)]
-NYears <- length(Years)
-NY <- length(Years)
-
-## final depletion prior
+## Hard-coded values for a specific stock
 CStock <- "Marine fishes nei Pacific, Eastern Central"
 Years <- 1956:2015
-FinalDepleteBest <- Priors$DepletePrior[iStock]
-FinalDepleteCV <- Priors$DepleteCV[iStock]
-Kprior <- Priors$Kprior[iStock]
-InitialDepletePrior <- Priors$InitialDepletePrior[iStock]
-InitialDepleteCV <- Priors$InitialDepleteCV[iStock]
-Taxon <- c(Class="Actinopterygii", Order="", Family="", Genus="", Species="")
-  Priors[iStock, c("Class", "Order", "Family", "Genus", "Species")]
+FinalDepleteBest <- 0.15
+FinalDepleteCV <- 0.2
+Kprior <- 5
+InitialDepletePrior <- 0.8
+InitialDepleteCV <- 0.2
+Taxon <- c(Class="Actinopterygii", Order="", Family="", Genus="",
+           Species="")
 Years <- 1950:2015
-NYears <- length(Years)
+NY <- length(Years)
 Catch <- c(11200, 11300, 8700, 10000, 5800, 3400, 5200, 2700, 19200, 16400,
            25600, 40000, 31800, 34000, 30000, 38400, 50000, 78000, 88100, 86500,
            91500, 111100, 117100, 122300, 18936, 25178, 40793, 2575, 97035, 157754,
@@ -88,14 +32,24 @@ Catch <- c(11200, 11300, 8700, 10000, 5800, 3400, 5200, 2700, 19200, 16400,
            46688, 48924, 47367, 78814, 18464, 22498, 32557)
 
 ## settings
-devtools::load_all('C:/Users/Cole/sraplus')
-library(sraplus)
 nrep <- 10000
 set.seed(2323)
 ## Draw from priors for SIR
 draws <- draw.priors(N=nrep, InitialDepletePrior, InitialDepleteCV,
                      Kprior, Catch, Taxon)
 ## Run SIR to get posterior samples
-fit1 <- run.SIR(NY=NY, Catch=Catch, draws=draws, deplete.mean=FinalDepleteBest,
+fit <- run.SIR(Catch=Catch, draws=draws, deplete.mean=FinalDepleteBest,
                 deplete.cv=FinalDepleteCV )
 
+## Quick plot to show the output
+par(mfrow=c(3,1))
+plot(Years, Years, ylim=c(0,2),type="n",xlab=NA,
+     ylab="Depletion",main=CStock)
+trash <- apply(fit$depletion, 2, function(i) lines(Years,y=i, col=rgb(0,0,0,.1)))
+plot(Years,Years, ylim= c(0,1.05*max(fit$ssb)), type="n",xlab=NA,
+     ylab="Vulnerable Biomass")
+trash <- apply(fit$ssb, 2, function(i) lines(Years,y=i, col=rgb(0,0,0,.1)))
+## Same but for harvest rate (U)
+plot(Years,Years, ylim=c(0,1), type="n",xlab="Year",
+     ylab="Harvest rate (U)")
+trash <- apply(fit$U, 2, function(i) lines(Years,y=i, col=rgb(0,0,0,.1)))

--- a/inst/demo.R
+++ b/inst/demo.R
@@ -77,7 +77,7 @@ InitialDepletePrior <- Priors$InitialDepletePrior[iStock]
 InitialDepleteCV <- Priors$InitialDepleteCV[iStock]
 Taxon <- c(Class="Actinopterygii", Order="", Family="", Genus="", Species="")
   Priors[iStock, c("Class", "Order", "Family", "Genus", "Species")]
-Years <- 1956:2015
+Years <- 1950:2015
 NYears <- length(Years)
 Catch <- c(11200, 11300, 8700, 10000, 5800, 3400, 5200, 2700, 19200, 16400,
            25600, 40000, 31800, 34000, 30000, 38400, 50000, 78000, 88100, 86500,
@@ -96,6 +96,6 @@ set.seed(2323)
 draws <- draw.priors(N=nrep, InitialDepletePrior, InitialDepleteCV,
                      Kprior, Catch, Taxon)
 ## Run SIR to get posterior samples
-fit1 <- run.SIR(draws, deplete.mean=FinalDepleteBest,
-                deplete.cv=FinalDepleteCV)
+fit1 <- run.SIR(NY=NY, Catch=Catch, draws=draws, deplete.mean=FinalDepleteBest,
+                deplete.cv=FinalDepleteCV )
 

--- a/inst/demo.R
+++ b/inst/demo.R
@@ -60,55 +60,42 @@ AllYears=seq(1950,2015)
 ###########################
 iStock <- 4
 jStock <- which(CStock==StockList[iStock])
-## data inputs for chosen stock
+# data inputs for chosen stock
 Catch <- as.numeric(CatchData[jStock,])
 Years <- AllYears[which(is.na(Catch)==FALSE)]
 Catch <- Catch[which(is.na(Catch)==FALSE)]
 NYears <- length(Years)
 NY <- length(Years)
+
 ## final depletion prior
+CStock <- "Marine fishes nei Pacific, Eastern Central"
+Years <- 1956:2015
 FinalDepleteBest <- Priors$DepletePrior[iStock]
 FinalDepleteCV <- Priors$DepleteCV[iStock]
+Kprior <- Priors$Kprior[iStock]
+InitialDepletePrior <- Priors$InitialDepletePrior[iStock]
+InitialDepleteCV <- Priors$InitialDepleteCV[iStock]
+Taxon <- c(Class="Actinopterygii", Order="", Family="", Genus="", Species="")
+  Priors[iStock, c("Class", "Order", "Family", "Genus", "Species")]
+Years <- 1956:2015
+NYears <- length(Years)
+Catch <- c(11200, 11300, 8700, 10000, 5800, 3400, 5200, 2700, 19200, 16400,
+           25600, 40000, 31800, 34000, 30000, 38400, 50000, 78000, 88100, 86500,
+           91500, 111100, 117100, 122300, 18936, 25178, 40793, 2575, 97035, 157754,
+           137998, 247485, 32678, 43009, 93478, 107547, 111452, 90206, 85661, 78127,
+           243749, 269734, 147620, 120349, 174176, 238947, 180690, 131611, 113369,
+           66776, 83729, 71432, 74800, 72603, 59766, 72231, 75397, 51974, 59222,
+           46688, 48924, 47367, 78814, 18464, 22498, 32557)
 
 ## settings
 devtools::load_all('C:/Users/Cole/sraplus')
+library(sraplus)
 nrep <- 10000
 set.seed(2323)
 ## Draw from priors for SIR
-draws <- draw.priors(nrep, iStock)
+draws <- draw.priors(N=nrep, InitialDepletePrior, InitialDepleteCV,
+                     Kprior, Catch, Taxon)
 ## Run SIR to get posterior samples
-fit1 <- run.SIR(draws, deplete.mean=FinalDepleteBest, deplete.cv=FinalDepleteCV)
-fit2 <- run.SIR(draws, deplete.mean=FinalDepleteBest, deplete.cv=FinalDepleteCV/10)
-fit3 <- run.SIR(draws, deplete.mean=FinalDepleteBest,
-                deplete.cv=FinalDepleteCV, harvest.mean=.5, harvest.sd=.01)
+fit1 <- run.SIR(draws, deplete.mean=FinalDepleteBest,
+                deplete.cv=FinalDepleteCV)
 
-## Quick exploratory plots
-png(paste0("fits_", iStock, ".png"), width=9, height=6, units='in', res=300)
-par(mfcol=c(3,3), mar=c(.1,4,2,.5), oma=c(3, 1, 3, .5))
-## Plot depletion trajectories
-fits <- list(fit1, fit2, fit3)
-for(i in 1:3){
-  temp <- fits[[i]]
-  ## use consistent SSB ylim
-  ylim <- c(0,1.05*max(unlist(lapply(fits, function(x) x$ssb))))
-  labels <- c("Standard", "Very informative depletion", "Very informative harvest")
-  plot(Years, Years, ylim=c(0,2),type="n",xlab=NA,
-       ylab="Depletion",main=labels[i])
-  trash <- apply(temp$depletion, 2, function(i) lines(Years,y=i, col=rgb(0,0,0,.1)))
-  abline(h=FinalDepleteBest,col="red",lwd=3)
-  ## Same but for biomass
-  plot(Years,Years, ylim=ylim, type="n",xlab=NA,
-       ylab="Vulnerable Biomass")
-  trash <- apply(temp$ssb, 2, function(i) lines(Years,y=i, col=rgb(0,0,0,.1)))
-  ## Same but for harvest rate (U)
-  plot(Years,Years, ylim=c(0,1), type="n",xlab="Year",
-       ylab="Harvest rate (U)")
-  trash <- apply(temp$U, 2, function(i) lines(Years,y=i, col=rgb(0,0,0,.1)))
-  mtext(StockList[iStock], outer=TRUE, line=1)
-}
-dev.off()
-## Pairs plot of parameters priors and posterior
-
-## post.ind <- 1:ncol(temp$depletion) %in% temp$Keepers # which prior draws were "kept"
-## pairs(draws[,1:5], col=ifelse(post.ind, 'red', 'black'),
-##       cex=ifelse(post.ind, 1, .1))


### PR DESCRIPTION
Restructuring to remove dependencies on the stocks as originally provided. Functions for generating priors and running model are now dependent only on local arguments passed top level by the user.