### PR TITLE
Add msy

### DIFF
--- a/R/SIR.R
+++ b/R/SIR.R
@@ -22,6 +22,7 @@ run.SIR <- function(Catch, draws, deplete.mean=NULL, deplete.cv=NULL,
   Bstore <- array(dim=c(NY,nrep))
   Dstore <- array(dim=c(NY,nrep))
   Ustore <- array(dim=c(NY,nrep))
+  Uscaledstore <- array(dim=c(NY,nrep))
   LikeStore <- array(dim=nrep)
   umsy <- cmsy <- rep(NA, len=nrep)
   B <- array(dim=(NY+1))  #stock biomass
@@ -73,6 +74,7 @@ run.SIR <- function(Catch, draws, deplete.mean=NULL, deplete.cv=NULL,
     Bstore[,irep] <- pop
     Dstore[,irep] <- Deplete
     Ustore[,irep] <- out$hr
+    Uscaledstore[,irep] <- uscaled
     LikeStore[irep] <- like
     cmsy[irep] <- out$cmsy
     umsy[irep] <- out$umsy
@@ -101,12 +103,12 @@ run.SIR <- function(Catch, draws, deplete.mean=NULL, deplete.cv=NULL,
   ##   Nhits <- length(j)
   ##   if (Nhits>0) {Keepers[k:(k+Nhits-1)] <-  i; k <- k+Nhits}
   ## }
-  Keepers <- get.keepers(Nkeep, CumLike, BreakPoints)
-  print(paste("% unique draws=",100*length(unique(Keepers))/Nkeep))
-
-  return(list(depletion=Dstore[, Keepers], ssb=Bstore[,Keepers],
-              U=Ustore[,Keepers], final=list(deplete.mean=deplete.mean,
-              deplete.cv=deplete.cv, harvest.mean=harvest.mean,
-              harvest.sd=harvest.sd), Keepers=Keepers,
-              umsy=umsy[Keepers], cmsy=cmsy[Keepers]))
+  K <- get.keepers(Nkeep, CumLike, BreakPoints)
+  print(paste("% unique draws=",100*length(unique(K))/Nkeep))
+  final <- list(deplete.mean=deplete.mean,
+                deplete.cv=deplete.cv, harvest.mean=harvest.mean,
+                harvest.sd=harvest.sd)
+  return(list(depletion=Dstore[, K], ssb=Bstore[,K],
+              U=Ustore[,K], Keepers=K, final=final, umsy=umsy[K],
+              cmsy=cmsy[K], uscaled=Uscaledstore[,K]))
 }

--- a/R/model.R
+++ b/R/model.R
@@ -32,11 +32,7 @@ AgeModel <- function(Catch, AgeMat, Steep, NatMort, AgeMax,
   ## maximum age
   maxage <- AgeMax
   ## natural survival
-  if(use.sim){
-    surv <- 1-exp(-NatMort-simulation$FishMort)
-  } else {
-    surv  <-  1-NatMort
-  }
+  surv  <-  1-NatMort
   ## num is numbers at age; vuln is vulnerability
   num <- vuln <- rep(1,maxage)
   ## 100% selectivity option

--- a/R/model.R
+++ b/R/model.R
@@ -18,6 +18,8 @@ AgeModel <- function(Catch, AgeMat, Steep, NatMort, AgeMax,
   stopifnot(AgeMat>0)
   use.sim <- !is.null(simulation)
   if(use.sim){
+    stopifnot(is.numeric(simulation$FishMort))
+    stopifnot(simulation$FishMort>=0); stopifnot(simulation$FishMort<=1)
     NYears <- simulation$NYears
   } else {
     NYears <- length(Catch)
@@ -104,23 +106,12 @@ AgeModel <- function(Catch, AgeMat, Steep, NatMort, AgeMax,
   ## Calculate UMSY
   ##  Weight <- c(0.35, 0.57, 0.78, 0.97, 1.14, 1.27, 1.37, 1.46, 1.52, 1.57, 1.60, 1.63, 1.65, 1.67, 1.68, 1.68)
   get.equilibrium.catch <- function(U){
-    stopifnot(is.numeric(U))
-    stopifnot(U>=0); stopifnot(U<=1)
-    num0 <- num <- rep(NA, len=maxage)
-    ## equilibrium numbers at age under no fishing
-    for (a in 1:maxage) {
-      if (a==1) num0[a]  <-  rzeroC   else num0[a] <- num0[a-1]*surv
-      ## plus group
-      if (a==maxage)
-        num0[a]  <- num0[a-1]*surv / (1-surv)
-    }
     ## equilibrium numbers at age under rate U
-    for (a in 1:maxage) {
-      if (a==1) num[a]  <-  rzeroC   else num[a]  <-  (1-vuln[a-1]*U)*num[a-1]*surv
-      ## plus group
-      if (a==maxage)
-        num[a]  <- num[a-1]*( (1-vuln[a-1]*U)*surv / (1-(1-vuln[a-1]*U)*surv) )
-    }
+    num[1]  <-  rzeroC
+    for (a in 2:(maxage-1))
+      num[a]  <-  (1-vuln[a-1]*U)*num[a-1]*surv
+    ## plus group
+    num[maxage]  <- num[a-1]*( (1-vuln[a-1]*U)*surv / (1-(1-vuln[a-1]*U)*surv) )
     ## Now get equilibrium recruitment for U
     ## SBPR0 <- sum(Weight*mature*num0)/rzeroC
     ## SSB0 <- SBPR0*rzeroC

--- a/R/model.R
+++ b/R/model.R
@@ -112,9 +112,6 @@ AgeModel <- function(Catch, AgeMat, Steep, NatMort, AgeMax,
       num[a]  <-  (1-vuln[a-1]*U)*num[a-1]*surv
     ## plus group
     num[maxage]  <- num[a-1]*( (1-vuln[a-1]*U)*surv / (1-(1-vuln[a-1]*U)*surv) )
-    ## Now get equilibrium recruitment for U
-    ## SBPR0 <- sum(Weight*mature*num0)/rzeroC
-    ## SSB0 <- SBPR0*rzeroC
     ## spwaning biomass per recruit fishing at U
     SBPR <- sum(Weight*mature*num)/rzeroC
     ## recruits in equilibrium fishing at U
@@ -125,7 +122,8 @@ AgeModel <- function(Catch, AgeMat, Steep, NatMort, AgeMax,
     ## Calculate catch for all recruits
     return(R*YPR)
   }
-  fit <- optimize(get.equilibrium.catch, interval=c(0,1), maximum=TRUE)
+  fit <- optimize(get.equilibrium.catch, interval=c(0,1), maximum=TRUE,
+                  tol=.001)
   out <- list(pop=pop, hr=hrstore, umsy=fit$maximum, cmsy=fit$objective)
   if(use.sim){
     u.seq <- seq(0,1, len=100)

--- a/R/model.R
+++ b/R/model.R
@@ -110,7 +110,6 @@ AgeModel <- function(Catch, AgeMat, Steep, NatMort, AgeMax,
   get.equilibrium.catch <- function(U){
     stopifnot(is.numeric(U))
     stopifnot(U>=0); stopifnot(U<=1)
-    rzeroC <- 1000
     num0 <- num <- rep(NA, len=maxage)
     ## equilibrium numbers at age under no fishing
     for (a in 1:maxage) {
@@ -127,23 +126,23 @@ AgeModel <- function(Catch, AgeMat, Steep, NatMort, AgeMax,
         num[a]  <- num[a-1]*( (1-vuln[a-1]*U)*surv / (1-(1-vuln[a-1]*U)*surv) )
     }
     ## Now get equilibrium recruitment for U
-    SBPR0 <- sum(Weight*mature*num0)/rzeroC
-    SSB0 <- SBPR0*rzeroC
+    ## SBPR0 <- sum(Weight*mature*num0)/rzeroC
+    ## SSB0 <- SBPR0*rzeroC
+    ## spwaning biomass per recruit fishing at U
     SBPR <- sum(Weight*mature*num)/rzeroC
-    R <- (SBPR-alpha)/(betav*SBPR)
-    SSB <- SBPR*R
-    ## and equlibrium catch
+    ## recruits in equilibrium fishing at U
+    R <- max(0, (SBPR-alpha)/(betav*SBPR))
+    ## and equlibrium catch per recruit?
     Ca <- sum(num*vuln*Weight*U)
     YPR <- Ca/rzeroC
-    return(max(0,R*YPR))
+    ## Calculate catch for all recruits
+    return(R*YPR)
   }
-  u.seq <- seq(0,1, len=100)
-  c.seq <- sapply(u.seq, function(u) get.equilibrium.catch(u))
-  ## plot(u.seq, c.seq)
   fit <- optimize(get.equilibrium.catch, interval=c(0,1), maximum=TRUE)
-  points(fit$maximum, fit$objective, pch=16, col=2)
   out <- list(pop=pop, hr=hrstore, umsy=fit$maximum, cmsy=fit$objective)
   if(use.sim){
+    u.seq <- seq(0,1, len=100)
+    c.seq <- sapply(u.seq, function(u) get.equilibrium.catch(u))
     o <- list(num0=num0, num=num, Catch=Catch,
               CatchEquilibrium=get.equilibrium.catch(simulation$FishMort),
               u.seq=u.seq, c.seq=c.seq)


### PR DESCRIPTION
Restructure agemodel to be in terms of instantaneous U and to calculate a UMSY for each draw. The approach currently calculates equilibrium SPR and equilibrium catch per recruit, then uses the stock recruit info to calculate equilibrium catch. However, a numerical optimizer is still used to find UMSY and this is quite slow relative to the rest of the model. I also added a small simulation component which was useful for testing correct functionality but is limited and should be expanded further.